### PR TITLE
RK3326: Fix RG351MP/RG351V-V2 issues, fix RGB10Max1 key mapping, add …

### DIFF
--- a/projects/ROCKNIX/config.xml
+++ b/projects/ROCKNIX/config.xml
@@ -19,6 +19,8 @@
   <RK3326 mkimage_options="dtb,bootscr,extlinux,uboot,rk3326_dtb_select" fdt_type="fdtdir" fdt="/" dtb_prefix="rockchip">
     <file>rk3326-anbernic-rg351m</file>
     <file>rk3326-anbernic-rg351v</file>
+    <file>rk3326-anbernic-rg351v-panel2</file>
+    <file>rk3326-anbernic-rg351mp</file>
     <file>rk3326-gameconsole-r33s</file>
     <file>rk3326-gameconsole-r36s</file>
     <file>rk3326-gameconsole-r40s</file>
@@ -28,10 +30,12 @@
     <file>rk3326-odroid-go2-v11</file>
     <file>rk3326-odroid-go3</file>
     <file>rk3326-powkiddy-rgb10</file>
+    <file>rk3326-powkiddy-rgbv10</file>
     <file>rk3326-powkiddy-rgb10s</file>
     <file>rk3326-powkiddy-rgb10x</file>
     <file>rk3326-powkiddy-rgb20s</file>
     <file>rk3326-powkiddy-rgb10max1</file>
+    <file>rk3326-powkiddy-rgb10max2</file>
     <file>rk3326-magicx-xu-mini-m</file>
     <file>rk3326-gameconsole-eeclone</file>
     <file>rk3326-batlexp-g350</file>

--- a/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-anbernic-rg351mp.dts
+++ b/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-anbernic-rg351mp.dts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+* # Copyright (C) 2022-26 AURKNIX (https://github.com/AveyondFly)
+*/
+
+/dts-v1/;
+#include "rk3326-gameconsole-r36s.dts"
+
+/ {
+	model = "Anbernic RG351MP";
+	compatible = "anbernic,rg351mp", "rockchip,rk3326";
+};
+
+&internal_display {
+	compatible = "rocknix,generic-dsi";
+	panel_description =
+	"G size=52,70 delays=2,1,20,120,20 format=rgb888 lanes=4 flags=0xe03",
+	
+	"M clock=26400 horizontal=640,119,2,119 vertical=480,13,2,5 default=1",
+	"M clock=26400 horizontal=640,119,46,119 vertical=480,13,74,5",
+	"M clock=26400 horizontal=640,119,2,119 vertical=480,13,102,5",
+	"M clock=27140 horizontal=640,119,45,119 vertical=480,13,90,5",
+	"M clock=26450 horizontal=640,119,42,119 vertical=480,13,2,5",
+	"M clock=28520 horizontal=640,119,3,119 vertical=480,13,44,5",
+	"M clock=31440 horizontal=640,119,39,119 vertical=480,13,74,5",
+	"M clock=28650 horizontal=640,119,37,119 vertical=480,13,23,5",
+	"M clock=35210 horizontal=640,119,35,119 vertical=480,13,13,5",
+	"M clock=39600 horizontal=640,119,2,119 vertical=480,13,2,5",
+	"M clock=52800 horizontal=640,119,2,119 vertical=480,13,2,5",
+	
+	"I seq=ff30", "I seq=ff52", "I seq=ff01",
+	"I seq=e300",
+	"I seq=400a",
+	"I seq=0340", "I seq=0400", "I seq=0503",
+	"I seq=2412", "I seq=251e", "I seq=2628", "I seq=2752",
+	"I seq=2857", "I seq=2901", "I seq=2adf",
+	"I seq=389c", "I seq=39a7", "I seq=3a53",
+	"I seq=4400",
+	"I seq=493c",
+	"I seq=59fe", "I seq=5c00",
+	"I seq=9177", "I seq=9277",
+	"I seq=a055", "I seq=a150", "I seq=a49c", "I seq=a702",
+	"I seq=a801", "I seq=a901", "I seq=aafc", "I seq=ab28", "I seq=ac06", "I seq=ad06", "I seq=ae06", "I seq=af03",
+	"I seq=b008", "I seq=b126", "I seq=b228", "I seq=b328", "I seq=b433", "I seq=b508", "I seq=b626", "I seq=b708",
+	"I seq=b826",
+	"I seq=ff30", "I seq=ff52", "I seq=ff02",
+	"I seq=b00b", "I seq=b116", "I seq=b217", "I seq=b32c", "I seq=b432", "I seq=b53b", "I seq=b629", "I seq=b740",
+	"I seq=b80d", "I seq=b905", "I seq=ba12", "I seq=bb10", "I seq=bc12", "I seq=bd15", "I seq=be19", "I seq=bf0e",
+	"I seq=c016", "I seq=c10a",
+	"I seq=d00c", "I seq=d117", "I seq=d214", "I seq=d32e", "I seq=d432", "I seq=d53c", "I seq=d622", "I seq=d73d",
+	"I seq=d80d", "I seq=d907", "I seq=da13", "I seq=db13", "I seq=dc11", "I seq=dd15", "I seq=de19", "I seq=df10",
+	"I seq=e017", "I seq=e10a",
+	"I seq=ff30", "I seq=ff52", "I seq=ff03",
+	"I seq=002a", "I seq=012a", "I seq=022a", "I seq=032a", "I seq=0461", "I seq=0580", "I seq=06c7", "I seq=0701",
+	"I seq=0882", "I seq=0983",
+	"I seq=302a", "I seq=312a", "I seq=322a", "I seq=332a", "I seq=3461", "I seq=35c5", "I seq=3680", "I seq=3723",
+	"I seq=4082", "I seq=4183", "I seq=4280", "I seq=4381", "I seq=4411", "I seq=45e6", "I seq=46e5", "I seq=4711",
+	"I seq=48e8", "I seq=49e7",
+	"I seq=5002", "I seq=5101", "I seq=5204", "I seq=5303", "I seq=5411", "I seq=55ea", "I seq=56e9", "I seq=5711",
+	"I seq=58ec", "I seq=59eb",
+	"I seq=7e02", "I seq=7f80",
+	"I seq=e05a",
+	"I seq=b100", "I seq=b40e", "I seq=b50f", "I seq=b604", "I seq=b707",
+	"I seq=b806", "I seq=b905", "I seq=ba0f",
+	"I seq=c700",
+	"I seq=ca0e", "I seq=cb0f", "I seq=cc04", "I seq=cd07", "I seq=ce06", "I seq=cf05",
+	"I seq=d00f",
+	"I seq=810f", "I seq=840e", "I seq=850f", "I seq=8607", "I seq=8704",
+	"I seq=8805", "I seq=8906", "I seq=8a00",
+	"I seq=970f",
+	"I seq=9a0e", "I seq=9b0f", "I seq=9c07", "I seq=9d04", "I seq=9e05", "I seq=9f06",
+	"I seq=a000",
+	"I seq=ff30", "I seq=ff52", "I seq=ff02",
+	"I seq=0101", "I seq=02da", "I seq=03ba", "I seq=04a8", "I seq=059a", "I seq=0670", "I seq=07ff",
+	"I seq=0891", "I seq=0990", "I seq=0aff", "I seq=0b8f", "I seq=0c60", "I seq=0d58", "I seq=0e48", "I seq=0f38",
+	"I seq=102b",
+	"I seq=ff30", "I seq=ff52", "I seq=ff00",
+	"I seq=3602",
+	"I seq=3a70",
+	"I seq=11 wait=200",
+	"I seq=29 wait=10";
+};

--- a/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-anbernic-rg351v-panel2.dts
+++ b/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-anbernic-rg351v-panel2.dts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+* # Copyright (C) 2022-26 AURKNIX (https://github.com/AveyondFly)
+*/
+
+/dts-v1/;
+#include "rk3326-gameconsole-r36s.dts"
+
+/ {
+	model = "Anbernic RG351V";
+	compatible = "anbernic,rg351v", "rockchip,rk3326";
+};
+
+&internal_display {
+	compatible = "rocknix,generic-dsi";
+	panel_description =
+	"G size=52,70 delays=20,96,20,120,20 format=rgb888 lanes=4 flags=0xe03",
+	
+	"M clock=50000 horizontal=640,450,46,450 vertical=480,17,5,13 default=1",
+	"M clock=50000 horizontal=640,450,85,450 vertical=480,17,106,13",
+	"M clock=50000 horizontal=640,450,60,450 vertical=480,17,115,13",
+	"M clock=50010 horizontal=640,450,73,450 vertical=480,17,110,13",
+	"M clock=50140 horizontal=640,450,60,450 vertical=480,17,35,13",
+	"M clock=55870 horizontal=640,450,59,450 vertical=480,17,75,13",
+	"M clock=50400 horizontal=640,450,77,450 vertical=480,17,10,13",
+	"M clock=50310 horizontal=640,450,85,450 vertical=480,17,6,13",
+	"M clock=54600 horizontal=640,450,94,450 vertical=480,17,46,13",
+	"M clock=75470 horizontal=640,450,60,450 vertical=480,17,115,13",
+	"M clock=74160 horizontal=640,450,60,450 vertical=480,17,5,13",
+	"M clock=98880 horizontal=640,450,60,450 vertical=480,17,5,13",
+	
+	"I seq=b9f11283",
+	"I seq=b1000000da80",
+	"I seq=b2001370",
+	"I seq=b31010282803ff00000000",
+	"I seq=b480",
+	"I seq=b50a0a",
+	"I seq=b67f7f",
+	"I seq=b82662f063",
+	"I seq=ba338105f90e0e2000000000000000442500900a0000014f01000037",
+	"I seq=bc47",
+	"I seq=bf021100",
+	"I seq=c0737350500000125000",
+	"I seq=c153c0323277e1dddd77773333",
+	"I seq=c68200bfff00ff",
+	"I seq=c7b8000a000000",
+	"I seq=c810401e02",
+	"I seq=cc0b",
+	"I seq=e000070d37353f4144060c0d0f111012141a00070d37353f4144060c0d0f111012141a",
+	"I seq=e307070b0b0b0b00000000ff00c010",
+	"I seq=e9c810020000b0b11131232880b0b127080004020000000004020000008888ba60240888888888888888ba713518888888888800000001000000000000000000",
+	"I seq=ea970a820203070000000000008188ba17538888888888888088ba0642888888888888230000028000000000000000000000000000000000000000000000",
+	"I seq=efffff01",
+	"I seq=11 wait=200",
+	"I seq=29 wait=50";
+};

--- a/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-powkiddy-rgb10max1.dts
+++ b/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-powkiddy-rgb10max1.dts
@@ -127,9 +127,14 @@
 			linux,code = <BTN_THUMBR>;// 0x2c3
 		};
 		sw13 {
-			gpios = <&gpio2 RK_PA1 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio3 RK_PB1 GPIO_ACTIVE_LOW>;
 			label = "GPIO BTN_FN";
 			linux,code = <BTN_MODE>;// 0x2c4
+		};
+		sw14 {
+			gpios = <&gpio3 RK_PB4 GPIO_ACTIVE_LOW>;
+			label = "GPIO BTN_FN2";
+			linux,code = <BTN_TRIGGER_HAPPY1>;// 0x13c
 		};
 		sw15 {
 			gpios = <&gpio2 RK_PA6 GPIO_ACTIVE_LOW>;
@@ -189,12 +194,12 @@
 		pinctrl-names = "default";
 		
 		button-vol-down {
-			gpios = <&gpio3 RK_PB1 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio2 RK_PA1 GPIO_ACTIVE_LOW>;
 			label = "VOLUMEDOWN";
 			linux,code = <KEY_VOLUMEDOWN>;
 		};
 		button-volume-up {
-			gpios = <&gpio3 RK_PB4 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio2 RK_PA0 GPIO_ACTIVE_LOW>;
 			label = "VOLUMEUP";
 			linux,code = <KEY_VOLUMEUP>;
 		};
@@ -217,28 +222,29 @@
 	btns {
 		btn_pins: btn-pins {
 			rockchip,pins =
-			<1 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>,
-			<1 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>,
-			<1 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>,
-			<1 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>,
 			<1 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>,
 			<1 RK_PB5 RK_FUNC_GPIO &pcfg_pull_up>,
 			<1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_up>,
 			<1 RK_PB7 RK_FUNC_GPIO &pcfg_pull_up>,
-			<2 RK_PA1 RK_FUNC_GPIO &pcfg_pull_up>,
-			<2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>,
-			<2 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>,
+			<1 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>,
+			<1 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>,
+			<1 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>,
+			<1 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>,
 			<2 RK_PA4 RK_FUNC_GPIO &pcfg_pull_up>,
 			<2 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>,
+			<3 RK_PB1 RK_FUNC_GPIO &pcfg_pull_up>,
+			<3 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>,
 			<2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>,
 			<2 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>,
+			<2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>,
+			<3 RK_PB7 RK_FUNC_GPIO &pcfg_pull_up>,
 			<3 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>,
-			<3 RK_PB7 RK_FUNC_GPIO &pcfg_pull_up>;
+			<2 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
 		};
 		btn_pins_vol: btn-pins-vol {
 			rockchip,pins =
-			<3 RK_PB1 RK_FUNC_GPIO &pcfg_pull_up>,
-			<3 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>;
+			<2 RK_PA1 RK_FUNC_GPIO &pcfg_pull_up>,
+			<2 RK_PA0 RK_FUNC_GPIO &pcfg_pull_up>;
 		};
 	};
 };

--- a/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-powkiddy-rgb10max2.dts
+++ b/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-powkiddy-rgb10max2.dts
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+* # Copyright (C) 2022-26 AURKNIX (https://github.com/AveyondFly)
+*/
+
+#include "rk3326-powkiddy-rgb10max1.dts"
+
+/ {
+	model = "Powkiddy RGB10 Max 2";
+	compatible = "powkiddy,rgb10max2", "rockchip,rk3326";
+};
+
+&joypad {
+	compatible = "rocknix-singleadc-joypad";
+	
+	joypad-name = "retrogame_joypad";
+	joypad-product = <0x1101>;
+	joypad-revision = <0x0100>;
+	joypad-vendor = <0x484B>;
+	
+	status = "okay";
+	
+	/* gpio pincontrol setup */
+	pinctrl-names = "default";
+	pinctrl-0 = <&btn_pins>;
+	
+	/* Analog mux define */
+	io-channel-names = "amux_adc";
+	io-channels = <&saradc 1>;
+	
+	/* adc mux channel count */
+	amux-count = <4>;
+	/* non-default wiring */
+	amux-channel-mapping = <1 0 2 3>;
+	/* adc mux select(a,b) gpio */
+	amux-a-gpios = <&gpio3 RK_PB3 GPIO_ACTIVE_LOW>;
+	amux-b-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_LOW>;
+	/* adc mux enable gpio */
+	amux-en-gpios = <&gpio3 RK_PB5 GPIO_ACTIVE_LOW>;
+	
+	/* adc calculate scale */
+	button-adc-scale = <2>;
+	
+	/* adc deadzone range  */
+	button-adc-deadzone = <64>;
+	
+	/*
+	specifies fuzz value that is used to filter noise from
+	the event stream.
+	*/
+	button-adc-fuzz = <32>;
+	button-adc-flat = <32>;
+	
+	/*
+	Analog Stick data tuning value(precent)
+	p = positive direction, n = negative direction
+	report value = (real_adc_data * tuning_value) / 100
+	*/
+	abs_x-p-tuning = <300>;
+	abs_x-n-tuning = <300>;
+	
+	abs_y-p-tuning = <300>;
+	abs_y-n-tuning = <300>;
+	
+	abs_rx-p-tuning = <300>;
+	abs_rx-n-tuning = <300>;
+	
+	abs_ry-p-tuning = <300>;
+	abs_ry-n-tuning = <300>;
+	
+	/* poll device interval (ms), adc read interval */
+	poll-interval = <10>;
+	
+	/* gpio button auto repeat set value : default disable */
+	/*
+	autorepeat;
+	*/
+	invert-absx;
+	invert-absy;
+	invert-absrx;
+	
+	sw1 {
+		gpios = <&gpio1 RK_PB4 GPIO_ACTIVE_LOW>;
+		label = "GPIO DPAD-UP";
+		linux,code = <BTN_DPAD_UP>;// 0x220
+	};
+	sw2 {
+		gpios = <&gpio1 RK_PB5 GPIO_ACTIVE_LOW>;
+		label = "GPIO DPAD-DOWN";
+		linux,code = <BTN_DPAD_DOWN>;// 0x221
+	};
+	sw3 {
+		gpios = <&gpio1 RK_PB6 GPIO_ACTIVE_LOW>;
+		label = "GPIO DPAD-LEFT";
+		linux,code = <BTN_DPAD_LEFT>;// 0x222
+	};
+	sw4 {
+		gpios = <&gpio1 RK_PB7 GPIO_ACTIVE_LOW>;
+		label = "GPIO DPAD-RIGHT";
+		linux,code = <BTN_DPAD_RIGHT>;// 0x223
+	};
+	sw5 {
+		gpios = <&gpio1 RK_PA2 GPIO_ACTIVE_LOW>;
+		label = "GPIO KEY BTN-A";
+		linux,code = <BTN_EAST>;// 0x131
+	};
+	sw6 {
+		gpios = <&gpio1 RK_PA5 GPIO_ACTIVE_LOW>;
+		label = "GPIO BTN-B";
+		linux,code = <BTN_SOUTH>;// 0x130
+	};
+	sw7 {
+		gpios = <&gpio1 RK_PA6 GPIO_ACTIVE_LOW>;
+		label = "GPIO BTN-Y";
+		linux,code = <BTN_WEST>;// 0x134
+	};
+	sw8 {
+		gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_LOW>;
+		label = "GPIO BTN-X";
+		linux,code = <BTN_NORTH>;// 0x133
+	};
+	sw11 {
+		gpios = <&gpio2 RK_PA4 GPIO_ACTIVE_LOW>;
+		label = "GPIO BTN_THUMBL";
+		linux,code = <BTN_THUMBL>;// 0x2c2
+	};
+	sw12 {
+		gpios = <&gpio2 RK_PA5 GPIO_ACTIVE_LOW>;
+		label = "GPIO BTN_THUMBR";
+		linux,code = <BTN_THUMBR>;// 0x2c3
+	};
+	sw13 {
+		gpios = <&gpio3 RK_PB1 GPIO_ACTIVE_LOW>;
+		label = "GPIO BTN_FN";
+		linux,code = <BTN_MODE>;// 0x2c4
+	};
+	sw14 {
+		gpios = <&gpio3 RK_PB4 GPIO_ACTIVE_LOW>;
+		label = "GPIO BTN_FN2";
+		linux,code = <BTN_TRIGGER_HAPPY1>;// 0x13c
+	};
+	sw15 {
+		gpios = <&gpio2 RK_PA6 GPIO_ACTIVE_LOW>;
+		label = "GPIO TOP-LEFT";
+		linux,code = <BTN_TL>;// 0x02
+	};
+	sw16 {
+		gpios = <&gpio2 RK_PA7 GPIO_ACTIVE_LOW>;
+		label = "GPIO TOP-RIGHT";
+		linux,code = <BTN_TR>;// 0x05
+	};
+	sw19 {
+		gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
+		label = "GPIO BTN_SELECT";
+		linux,code = <BTN_SELECT>;
+	};
+	sw20 {
+		gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
+		label = "GPIO TOP-RIGHT2";
+		linux,code = <BTN_TR2>;
+	};
+	sw21 {
+		gpios = <&gpio3 RK_PB2 GPIO_ACTIVE_LOW>;
+		label = "GPIO TOP-LEFT2";
+		linux,code = <BTN_TL2>;
+	};
+	sw22 {
+		gpios = <&gpio2 RK_PA3 GPIO_ACTIVE_LOW>;
+		label = "GPIO BTN_START";
+		linux,code = <BTN_START>;
+	};
+}
+
+&battery {
+	compatible = "simple-battery";
+	charge-full-design-microamp-hours = <4200000>;
+	charge-term-current-microamp = <300000>;
+	constant-charge-current-max-microamp = <2000000>;
+	constant-charge-voltage-max-microvolt = <4200000>;
+	factory-internal-resistance-micro-ohms = <180000>;
+	voltage-max-design-microvolt = <4100000>;
+	voltage-min-design-microvolt = <3500000>;
+	
+	ocv-capacity-celsius = <20>;
+	ocv-capacity-table-0 =  <4046950 100>, <4001920 95>, <3967900 90>, <3919950 85>,
+	<3888450 80>, <3861850 75>, <3831540 70>, <3799130 65>,
+	<3768190 60>, <3745650 55>, <3726610 50>, <3711630 45>,
+	<3696720 40>, <3685660 35>, <3674950 30>, <3663050 25>,
+	<3649470 20>, <3635260 15>, <3616920 10>, <3592440 5>,
+	<3574170 0>;
+}

--- a/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-powkiddy-rgbv10.dts
+++ b/projects/ROCKNIX/devices/RK3326/linux/dts/rockchip/rk3326-powkiddy-rgbv10.dts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+* # Copyright (C) 2022-26 AURKNIX (https://github.com/AveyondFly)
+*/
+
+#include "rk3326-powkiddy-rgb10.dts"
+
+/ {
+	model = "Powkiddy RGBV10";
+	compatible = "powkiddy,rgbv10", "rockchip,rk3326";
+};

--- a/projects/ROCKNIX/devices/RK3326/packages/rk3326-dtb-select/dtb_selector.py
+++ b/projects/ROCKNIX/devices/RK3326/packages/rk3326-dtb-select/dtb_selector.py
@@ -261,8 +261,8 @@ ALL_DEVICES: Dict[str, DtbEntry] = {
     # 安伯尼克
     "安伯尼克 RG351M": DtbEntry("rk3326-anbernic-rg351m.dtb", 101),
     "安伯尼克 RG351V": DtbEntry("rk3326-anbernic-rg351v.dtb", 101),
-    "安伯尼克 RG351V P2屏幕": DtbEntry("rk3326-anbernic-rg351v.dtb", 101, "overlays-rg351v-p2"),
-    "安伯尼克 RG351MP": DtbEntry("rk3326-gameconsole-r36s.dtb", 202, "overlays-rg351mp-p2"),
+    "安伯尼克 RG351V P2屏幕": DtbEntry("rk3326-anbernic-rg351v-panel2.dtb", 101),
+    "安伯尼克 RG351MP": DtbEntry("rk3326-anbernic-rg351mp.dtb", 202),
 
     # 亿米创
     "YMC A10mini": DtbEntry("rk3326-portablegame-a10mini.dtb", 202),
@@ -278,10 +278,12 @@ ALL_DEVICES: Dict[str, DtbEntry] = {
 
     # 泡机堂
     "PowKiddy RGB10": DtbEntry("rk3326-powkiddy-rgb10.dtb", 101),
+    "PowKiddy RGBV10": DtbEntry("rk3326-powkiddy-rgbv10.dtb", 101),
     "PowKiddy RGB10X": DtbEntry("rk3326-powkiddy-rgb10x.dtb", 101),
     "PowKiddy RGB10S": DtbEntry("rk3326-powkiddy-rgb10s.dtb", 101),
     "PowKiddy RGB2OS": DtbEntry("rk3326-powkiddy-rgb20s.dtb", 202),
     "PowKiddy RGB10Max1": DtbEntry("rk3326-powkiddy-rgb10max1.dtb", 101),
+    "PowKiddy RGB10Max2": DtbEntry("rk3326-powkiddy-rgb10max2.dtb", 101),
 
     # GAMEMT
     "GAMEMT E6": DtbEntry("rk3326-gamemt-e6.dtb", 101),

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG351MP
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Anbernic RG351MP
@@ -1,0 +1,1 @@
+Game Console R36S

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Powkiddy RGB10 Max 2
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Powkiddy RGB10 Max 2
@@ -1,0 +1,1 @@
+Powkiddy RGB10 Max 1

--- a/projects/ROCKNIX/packages/hardware/quirks/devices/Powkiddy RGBV10
+++ b/projects/ROCKNIX/packages/hardware/quirks/devices/Powkiddy RGBV10
@@ -1,0 +1,1 @@
+Powkiddy RGB10


### PR DESCRIPTION
…support for RGBV10 and RGB10Max2

- Fix non-working issue for RG351MP and RG351V-V2 devices

- Correct key mapping error for RGB10Max1

- Add support for RGBV10 and RGB10Max2 devices

- Add corresponding device tree files and quirks configurations

## Summary

<!-- Describe what this PR changes and why. -->

## Test Plan

<!-- List the testing you performed, or write "Not tested" with a short reason. -->

## PR Image Build

<!-- Optional: request CI images by adding devices after build:, for example:
build:RK3326/RK3566

Supported devices: RK3326, RK3326S, RK3566, S905, RK356X.
Use build:ALL to build all devices. Leave build: empty to skip PR image builds. -->
build:RK3326/RK3566
