### PR TITLE
RK3326: add RTL8188FU WiFi driver

### DIFF
--- a/projects/ROCKNIX/devices/RK3326/options
+++ b/projects/ROCKNIX/devices/RK3326/options
@@ -58,12 +58,12 @@
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="RTL8812AU RTL8814AU RTL8821AU RTL8821CU RTL88x2BU RTL8851BU mali-bifrost rk915 aic8800-usb"
+    ADDITIONAL_DRIVERS="RTL8188FU RTL8812AU RTL8814AU RTL8821AU RTL8821CU RTL88x2BU RTL8851BU mali-bifrost rk915 aic8800-usb"
 
   # Additional Firmware to use ( )
   # Space separated list is supported,
   # e.g. FIRMWARE=""
-    FIRMWARE="esp8089-firmware"
+    FIRMWARE="esp8089-firmware RTL8188FU-firmware"
   
   # Additional packages to install
     ADDITIONAL_PACKAGES="device-switch libmali generic-dsi rk3326-dtb-select"

--- a/projects/ROCKNIX/devices/RK3326/patches/linux/026-wifi-rtl8xxxu-defer-rtl8188fu.patch
+++ b/projects/ROCKNIX/devices/RK3326/patches/linux/026-wifi-rtl8xxxu-defer-rtl8188fu.patch
@@ -1,0 +1,8 @@
+diff --git a/drivers/net/wireless/realtek/rtl8xxxu/core.c b/drivers/net/wireless/realtek/rtl8xxxu/core.c
+index 02a00e7..1cda256 100644
+--- a/drivers/net/wireless/realtek/rtl8xxxu/core.c
++++ b/drivers/net/wireless/realtek/rtl8xxxu/core.c
+@@ -8047,3 +8047,0 @@ static const struct usb_device_id dev_table[] = {
+-/* RTL8188FU */
+-{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_REALTEK, 0xf179, 0xff, 0xff, 0xff),
+-	.driver_info = (unsigned long)&rtl8188fu_fops},

--- a/projects/ROCKNIX/packages/linux-drivers/RTL8188FU/modprobe.d/rtl8188fu.conf
+++ b/projects/ROCKNIX/packages/linux-drivers/RTL8188FU/modprobe.d/rtl8188fu.conf
@@ -1,0 +1,1 @@
+options rtl8188fu rtw_power_mgnt=0 rtw_enusbss=0 rtw_ips_mode=0

--- a/projects/ROCKNIX/packages/linux-drivers/RTL8188FU/package.mk
+++ b/projects/ROCKNIX/packages/linux-drivers/RTL8188FU/package.mk
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present AURKNIX (https://github.com/AveyondFly)
+
+PKG_NAME="RTL8188FU"
+PKG_VERSION="c8c95708b3756c67139c456a2a6576c1e6491d82"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/kelebek333/rtl8188fu"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_SHA256="c960a881de261aa8065ac1a4277664d2e9f31187c6050c2c75d386e7832bb2df"
+PKG_LONGDESC="Realtek RTL8188FU out-of-tree USB WiFi driver"
+PKG_TOOLCHAIN="make"
+PKG_IS_KERNEL_PKG="yes"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  make V=1 \
+       ARCH=${TARGET_KERNEL_ARCH} \
+       KSRC=$(kernel_path) \
+       CROSS_COMPILE=${TARGET_KERNEL_PREFIX}
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/$(get_full_module_dir)/kernel/drivers/net/wireless
+    cp rtl8188fu.ko ${INSTALL}/$(get_full_module_dir)/kernel/drivers/net/wireless
+
+  mkdir -p ${INSTALL}/usr/lib/modprobe.d
+    cp ${PKG_DIR}/modprobe.d/rtl8188fu.conf ${INSTALL}/usr/lib/modprobe.d/
+}

--- a/projects/ROCKNIX/packages/linux-drivers/RTL8188FU/patches/001-use-exported-real-time-api.patch
+++ b/projects/ROCKNIX/packages/linux-drivers/RTL8188FU/patches/001-use-exported-real-time-api.patch
@@ -1,0 +1,7 @@
+diff --git a/os_dep/linux/ioctl_cfg80211.c b/os_dep/linux/ioctl_cfg80211.c
+index 122c9de..581dd42 100644
+--- a/os_dep/linux/ioctl_cfg80211.c
++++ b/os_dep/linux/ioctl_cfg80211.c
+@@ -361 +361 @@ static u64 rtw_get_systime_us(void)
+-	ktime_get_coarse_real_ts64(&ts);
++	ktime_get_real_ts64(&ts);


### PR DESCRIPTION
## Summary

- add the vendor RTL8188FU USB WiFi driver and existing firmware package to RK3326 images
- stop rtl8xxxu from claiming only the Realtek `0bda:f179` device ID
- disable driver power saving and USB autosuspend to avoid the duplicate packets and unstable throughput observed on A10mini
- patch the vendor driver to use an exported real-time kernel API on Linux 6.12

## Test Plan

- [x] Driver patch dry-run against pinned source commit `c8c95708b3756c67139c456a2a6576c1e6491d82`
- [x] Kernel patch dry-run against Linux 6.12.79
- [x] `git diff --check`
- [x] Manually built the same pinned driver on an A10mini running AURKNIX 6.12.79; verified `0bda:f179` binding, 72.2 Mbit/s link rate, and 0% loss over 100 pings
- [ ] RK3326 PR image build
- [ ] Flash and verify the generated image on A10mini

Local package build was attempted on an ARM64 Ubuntu host, but the current build framework unconditionally injects `-march=x86-64` into host tools. The requested x86_64 CI image build will provide the package and full-image validation.

## PR Image Build

build:RK3326