### PR TITLE
RK3326: add Dora SSR engine ports

### DIFF
--- a/projects/ROCKNIX/devices/RK3326/options
+++ b/projects/ROCKNIX/devices/RK3326/options
@@ -66,7 +66,7 @@
     FIRMWARE="esp8089-firmware"
   
   # Additional packages to install
-    ADDITIONAL_PACKAGES="device-switch libmali generic-dsi rk3326-dtb-select"
+    ADDITIONAL_PACKAGES="device-switch dora-ssr libmali generic-dsi rk3326-dtb-select"
     ADDITIONAL_PACKAGES_32BIT="libmali"
 
   # Debug tty path

--- a/projects/ROCKNIX/packages/apps/dora-ssr/autostart/012-dora-ssr
+++ b/projects/ROCKNIX/packages/apps/dora-ssr/autostart/012-dora-ssr
@@ -1,0 +1,32 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present AURKNIX (https://github.com/AveyondFly)
+
+PORTS_DIR=/storage/roms/ports
+GAMELIST="$PORTS_DIR/gamelist.xml"
+
+mkdir -p "$PORTS_DIR" /storage/.local/share/dora-ssr/logs
+cp -f "/usr/share/dora-ssr/ports/Dora SSR.sh" "$PORTS_DIR/Dora SSR.sh"
+cp -f "/usr/share/dora-ssr/ports/Dora Update.sh" "$PORTS_DIR/Dora Update.sh"
+chmod 0755 "$PORTS_DIR/Dora SSR.sh" "$PORTS_DIR/Dora Update.sh"
+
+if ! xmlstarlet val -q "$GAMELIST" 2>/dev/null; then
+  printf '%s\n' '<?xml version="1.0"?>' '<gameList />' > "$GAMELIST"
+fi
+
+add_game() {
+  path=$1
+  name=$2
+  image=$3
+
+  xmlstarlet ed --inplace -d "/gameList/game[path='$path']" "$GAMELIST"
+  xmlstarlet ed --inplace \
+    --subnode "/gameList" --type elem -n game -v "" \
+    --subnode "/gameList/game[last()]" --type elem -n path -v "$path" \
+    --subnode "/gameList/game[last()]" --type elem -n name -v "$name" \
+    --subnode "/gameList/game[last()]" --type elem -n image -v "$image" \
+    "$GAMELIST"
+}
+
+add_game "./Dora SSR.sh" "Dora SSR" "/usr/share/dora-ssr/Image/logo.png"
+add_game "./Dora Update.sh" "Dora Update" "/usr/share/dora-ssr/Image/icon.png"

--- a/projects/ROCKNIX/packages/apps/dora-ssr/package.mk
+++ b/projects/ROCKNIX/packages/apps/dora-ssr/package.mk
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present AURKNIX (https://github.com/AveyondFly)
+
+PKG_NAME="dora-ssr"
+PKG_VERSION="1.9.2-10"
+PKG_ARCH="aarch64"
+PKG_LICENSE="MIT"
+PKG_SITE="https://dora-ssr.net"
+PKG_URL="https://ppa.launchpadcontent.net/ippclub/dora-ssr/ubuntu/pool/main/d/dora-ssr/dora-ssr_${PKG_VERSION}_arm64.deb"
+PKG_SHA256="e201f0b4c54fb2dcecec994db2f290ed0e70ccd1ab32d4e84a30d099f45b89c4"
+PKG_DEPENDS_HOST="zstd:host"
+PKG_DEPENDS_TARGET="toolchain alsa-lib binutils curl dbus foot gzip libdrm mesa util-linux xmlstarlet zstd"
+PKG_LONGDESC="Dora SSR game engine with KMSDRM launch and PPA update support"
+PKG_TOOLCHAIN="manual"
+
+unpack() {
+  mkdir -p ${PKG_BUILD}
+  (
+    cd ${PKG_BUILD}
+    ar x ${SOURCES}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.deb
+    zstd -dc data.tar.zst | tar -x
+  )
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+  cp ${PKG_BUILD}/usr/bin/dora-ssr ${INSTALL}/usr/bin/
+  cp ${PKG_DIR}/scripts/* ${INSTALL}/usr/bin/
+  chmod 0755 ${INSTALL}/usr/bin/dora-ssr \
+             ${INSTALL}/usr/bin/dora-kmsdrm-runner \
+             ${INSTALL}/usr/bin/dora-update-runner
+
+  mkdir -p ${INSTALL}/usr/share/dora-ssr
+  cp -a ${PKG_BUILD}/usr/share/dora-ssr/. ${INSTALL}/usr/share/dora-ssr/
+  mkdir -p ${INSTALL}/usr/share/dora-ssr/ports
+  cp ${PKG_DIR}/ports/* ${INSTALL}/usr/share/dora-ssr/ports/
+  chmod 0755 ${INSTALL}/usr/share/dora-ssr/ports/*
+  echo "${PKG_VERSION}" > ${INSTALL}/usr/share/dora-ssr/version
+
+  mkdir -p ${INSTALL}/usr/lib/autostart/common
+  cp ${PKG_DIR}/autostart/012-dora-ssr ${INSTALL}/usr/lib/autostart/common/
+  chmod 0755 ${INSTALL}/usr/lib/autostart/common/012-dora-ssr
+}

--- a/projects/ROCKNIX/packages/apps/dora-ssr/ports/Dora SSR.sh
+++ b/projects/ROCKNIX/packages/apps/dora-ssr/ports/Dora SSR.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -u
+
+source /etc/profile
+
+set_kill set "dora-ssr"
+
+DORA_BASE=/storage/.local/share/dora-ssr
+DORA_LOG="$DORA_BASE/logs/dora-ssr.log"
+UNIT=dora-ssr-kmsdrm.service
+
+mkdir -p "$DORA_BASE/logs"
+
+if systemctl is-active --quiet "$UNIT"; then
+  exit 0
+fi
+
+systemctl reset-failed "$UNIT" >/dev/null 2>&1 || true
+systemd-run \
+  --unit="${UNIT%.service}" \
+  --collect \
+  --property=TimeoutStopSec=15 \
+  /usr/bin/dora-kmsdrm-runner >> "$DORA_LOG" 2>&1

--- a/projects/ROCKNIX/packages/apps/dora-ssr/ports/Dora Update.sh
+++ b/projects/ROCKNIX/packages/apps/dora-ssr/ports/Dora Update.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+source /etc/profile
+set -u
+
+set_kill set "dora-update"
+
+DORA_BASE=/storage/.local/share/dora-ssr
+
+mkdir -p "$DORA_BASE/logs"
+
+if pgrep -f "/usr/bin/dora-update-runner" >/dev/null; then
+  exit 0
+fi
+
+exec foot \
+  --fullscreen \
+  --title="Dora Update" \
+  --app-id=dora-update \
+  --override=font=monospace:size=14 \
+  /usr/bin/dora-update-runner

--- a/projects/ROCKNIX/packages/apps/dora-ssr/scripts/dora-kmsdrm-runner
+++ b/projects/ROCKNIX/packages/apps/dora-ssr/scripts/dora-kmsdrm-runner
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -u
+
+source /etc/profile
+
+DORA_BASE=/storage/.local/share/dora-ssr
+DORA_ROOT="$DORA_BASE/current"
+DORA_LOG="$DORA_BASE/logs/dora-ssr.log"
+
+if [ -x "$DORA_ROOT/usr/bin/dora-ssr" ]; then
+  DORA_BIN="$DORA_ROOT/usr/bin/dora-ssr"
+  DORA_ASSET="$DORA_ROOT/usr/share/dora-ssr"
+else
+  DORA_BIN=/usr/bin/dora-ssr
+  DORA_ASSET=/usr/share/dora-ssr
+fi
+
+restore_ui() {
+  echo "$(date): restoring Sway and EmulationStation" >> "$DORA_LOG"
+  systemctl start sway.service
+  systemctl start essway.service
+}
+
+trap restore_ui EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+mkdir -p "$DORA_BASE/logs"
+
+if [ ! -x "$DORA_BIN" ]; then
+  echo "$(date): Dora SSR executable not found: $DORA_BIN" >> "$DORA_LOG"
+  exit 1
+fi
+
+echo "$(date): stopping Sway for Dora KMSDRM" >> "$DORA_LOG"
+systemctl stop essway.service
+systemctl stop sway.service
+
+for _ in $(seq 1 20); do
+  if ! pgrep -x sway >/dev/null; then
+    break
+  fi
+  sleep 0.25
+done
+
+export HOME=/storage
+export SDL_VIDEODRIVER=kmsdrm
+export SDL_KMSDRM_REQUIRE_DRM_MASTER=1
+export SDL_KMSDRM_DISABLE_CURSOR=1
+export SDL_KMSDRM_DEVICE_INDEX=0
+export SDL_GAMECONTROLLERCONFIG_FILE=/storage/.config/SDL-GameControllerDB/gamecontrollerdb.txt
+unset DISPLAY WAYLAND_DISPLAY SWAYSOCK
+
+clear > /dev/console 2>/dev/null || true
+cd /storage || exit 1
+
+echo "$(date): starting Dora SSR with KMSDRM" >> "$DORA_LOG"
+"$DORA_BIN" --asset "$DORA_ASSET" >> "$DORA_LOG" 2>&1
+status=$?
+echo "$(date): Dora SSR exited with status $status" >> "$DORA_LOG"
+exit "$status"

--- a/projects/ROCKNIX/packages/apps/dora-ssr/scripts/dora-update-runner
+++ b/projects/ROCKNIX/packages/apps/dora-ssr/scripts/dora-update-runner
@@ -1,0 +1,97 @@
+#!/bin/bash
+source /etc/profile
+set -euo pipefail
+
+DORA_BASE=/storage/.local/share/dora-ssr
+DORA_RELEASES="$DORA_BASE/releases"
+DORA_LOG="$DORA_BASE/logs/dora-update.log"
+PACKAGES_URL=https://ppa.launchpadcontent.net/ippclub/dora-ssr/ubuntu/dists/jammy/main/binary-arm64/Packages.gz
+PPA_ROOT=https://ppa.launchpadcontent.net/ippclub/dora-ssr/ubuntu
+work=
+
+mkdir -p "$DORA_RELEASES" "$DORA_BASE/logs"
+exec > >(tee -a "$DORA_LOG") 2>&1
+
+cleanup() {
+  case "${work:-}" in
+    "$DORA_BASE"/.update-*) rm -rf -- "$work" ;;
+  esac
+}
+
+finish() {
+  status=$?
+  trap - EXIT INT TERM
+  cleanup
+  printf '\n============================================================\n'
+  if [ "$status" -eq 0 ]; then
+    echo '                 UPDATE SUCCESSFUL'
+  else
+    echo "                 UPDATE FAILED (code $status)"
+    echo "See log: $DORA_LOG"
+  fi
+  printf '============================================================\n\n'
+  echo 'Returning to EmulationStation in 10 seconds...'
+  sleep 10
+  exit "$status"
+}
+
+trap finish EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+clear
+echo 'Dora SSR Updater'
+echo '================'
+echo
+
+exec 9>"$DORA_BASE/.update.lock"
+if ! flock -n 9; then
+  echo 'Another Dora update is already running.'
+  exit 1
+fi
+
+work=$(mktemp -d "$DORA_BASE/.update-XXXXXX")
+
+echo "[$(date '+%F %T')] Checking Dora SSR PPA..."
+curl --http1.1 --retry 5 --retry-delay 2 -fsSL "$PACKAGES_URL" -o "$work/Packages.gz"
+gzip -dc "$work/Packages.gz" > "$work/Packages"
+
+version=$(awk '$1 == "Package:" { selected = ($2 == "dora-ssr") } selected && $1 == "Version:" { print $2; exit }' "$work/Packages")
+filename=$(awk '$1 == "Package:" { selected = ($2 == "dora-ssr") } selected && $1 == "Filename:" { print $2; exit }' "$work/Packages")
+checksum=$(awk '$1 == "Package:" { selected = ($2 == "dora-ssr") } selected && $1 == "SHA256:" { print $2; exit }' "$work/Packages")
+
+if [ -z "$version" ] || [ -z "$filename" ] || [ -z "$checksum" ]; then
+  echo 'Unable to find the ARM64 dora-ssr package in the PPA index.'
+  exit 1
+fi
+
+echo "Latest version: $version"
+release="$DORA_RELEASES/$version"
+if [ ! -x "$release/usr/bin/dora-ssr" ]; then
+  if [ -x /usr/bin/dora-ssr ] && [ "$(cat /usr/share/dora-ssr/version 2>/dev/null || true)" = "$version" ]; then
+    if [ -L "$DORA_BASE/current" ]; then
+      rm -f "$DORA_BASE/current"
+    fi
+    echo "Dora SSR $version is included in this AURKNIX image."
+    exit 0
+  fi
+
+  echo "Downloading Dora SSR $version..."
+  curl --http1.1 --retry 5 --retry-delay 2 -fL "$PPA_ROOT/$filename" -o "$work/dora.deb"
+  echo 'Verifying package checksum...'
+  printf '%s  %s\n' "$checksum" "$work/dora.deb" | sha256sum -c -
+
+  echo 'Installing package...'
+  mkdir -p "$work/ar" "$work/root"
+  cd "$work/ar"
+  ar x "$work/dora.deb"
+  zstd -dc data.tar.zst | tar -x -C "$work/root"
+  test -x "$work/root/usr/bin/dora-ssr"
+  test -f "$work/root/usr/share/dora-ssr/Image/logo.png"
+  mv "$work/root" "$release"
+else
+  echo "Dora SSR $version is already installed."
+fi
+
+ln -sfn "releases/$version" "$DORA_BASE/current"
+echo "[$(date '+%F %T')] Dora SSR is now $version."


### PR DESCRIPTION
## Summary

- add the ARM64 Dora SSR engine from its checksum-pinned Ubuntu PPA package to RK3326 images
- add `Dora SSR` and `Dora Update` entries to Ports with the packaged `logo.png` and `icon.png` artwork
- launch Dora directly through SDL KMSDRM, temporarily stop Sway/EmulationStation, restore both on exit, and disable the KMSDRM cursor plane
- provide a fullscreen updater that verifies the PPA package SHA-256 and installs newer releases under `/storage`
- keep all changes under `projects/ROCKNIX`

## Test Plan

- [x] `scripts/get dora-ssr` downloads the pinned `1.9.2-10` ARM64 PPA package and verifies SHA-256
- [x] `scripts/clean dora-ssr` followed by `scripts/unpack dora-ssr`
- [x] Verified the extracted binary is AArch64 ELF and the package contains 512x512 `logo.png` and 1024x1024 `icon.png`
- [x] Bash syntax check, ShellCheck warning-level check, and `git diff --check`
- [x] Applied the gamelist update twice with XMLStarlet; the existing entry was preserved and each Dora entry appeared exactly once
- [x] The same KMSDRM launcher, updater, PPA package, and cursor-plane environment were tested on an A10mini running AURKNIX 6.12.79
- [x] RK3326 PR image build
- [ ] Flash and verify both Ports entries, images, launch, exit restoration, and update flow on A10mini

A complete x86_64 GitHub Actions RK3326 build now passes with the Dora SSR integration and the source/mirror fixes combined. Run [32955106824](https://github.com/pigpigyyy/distribution_rocknix/actions/runs/32955106824) produced the base image plus SHA-256, completed the RK3326 modules build, and uploaded both build-directory artifacts. Hardware validation remains intentionally separate.

## PR Image Build

build:RK3326