### PR TITLE
build: use repository-owned source mirror

### DIFF
--- a/.github/workflows/update-mirror-sources.yml
+++ b/.github/workflows/update-mirror-sources.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       SKIP_GIT: true
+      GET_MAX_ATTEMPTS: 2
       GH_TOKEN: ${{ secrets.GH_PAT }}
     steps:
       - name: Maximize build space
@@ -41,16 +42,29 @@ jobs:
             fi
           done
       - name: print number of downloaded artifacts
-        run: find sources/ -type f \( -name "*.tar.gz" -o -name "*.tar.xz" -o -name "*.tgz" -o -name "*.tar.bz2" -o -name "*.deb" \) | wc -l
+        run: find sources/ -type f -name "*.sha256" | wc -l
       - name: Find missing artifacts
         id: find_missing
         run: |
           set -euo pipefail
           EXISTING_FILES=$(gh release view sources --repo "${{ github.repository_owner }}/distribution-sources" --json assets --jq '.assets[].name' || true)
-          mapfile -t LOCAL_FILES < <(find sources/ -type f \( -name '*.tar.gz' -o -name '*.tar.xz' -o -name '*.tgz' -o -name '*.tar.bz2' -o -name '*.deb' -o -name '*.tar.zst' \))
+          mapfile -d '' -t SHA_FILES < <(find sources/ -type f -name '*.sha256' -print0)
           
           MISSING_FILES=()
-          for file in "${LOCAL_FILES[@]}"; do
+          for sha_file in "${SHA_FILES[@]}"; do
+            file="${sha_file%.sha256}"
+            if [ ! -f "$file" ]; then
+              echo "::warning::Skipping source without archive: $file"
+              continue
+            fi
+
+            expected_sha=$(tr -d '[:space:]' < "$sha_file")
+            actual_sha=$(sha256sum "$file" | cut -d ' ' -f 1)
+            if [ -z "$expected_sha" ] || [ "$expected_sha" != "$actual_sha" ]; then
+              echo "::warning::Skipping source with invalid checksum: $file"
+              continue
+            fi
+
             BASENAME=$(basename "$file")
             if ! echo "$EXISTING_FILES" | grep -qx "$BASENAME"; then
               echo "Missing: $file"

--- a/.github/workflows/update-mirror-sources.yml
+++ b/.github/workflows/update-mirror-sources.yml
@@ -33,27 +33,20 @@ jobs:
       - name: install xmlstarlet
         run: sudo apt-get install xmlstarlet
       - name: get sources
-        uses: corrupt952/actions-retry-command@v1.0.7
-        with:
-          command: |
-            PROJECT=ROCKNIX DEVICE=RK3326 ./tools/download-tool 
-            PROJECT=ROCKNIX DEVICE=RK3326S ./tools/download-tool 
-            PROJECT=ROCKNIX DEVICE=RK3399 ./tools/download-tool 
-            PROJECT=ROCKNIX DEVICE=RK3566 ./tools/download-tool 
-            PROJECT=ROCKNIX DEVICE=RK3588 ./tools/download-tool 
-            PROJECT=ROCKNIX DEVICE=H700 ./tools/download-tool 
-            PROJECT=ROCKNIX DEVICE=S922X ./tools/download-tool 
-            PROJECT=ROCKNIX DEVICE=SM8250 ./tools/download-tool 
-            PROJECT=ROCKNIX DEVICE=SM8550 ./tools/download-tool
-          max_attempts: 6
-          retry_interval: 10
+        run: |
+          DEVICES=(RK3326 RK3326S RK3399 RK3566 RK3588 H700 S922X SM8250 SM8550)
+          for DEVICE in "${DEVICES[@]}"; do
+            if ! PROJECT=ROCKNIX DEVICE="${DEVICE}" ./tools/download-tool; then
+              echo "::warning::Source download for ${DEVICE} was incomplete; uploading successful downloads."
+            fi
+          done
       - name: print number of downloaded artifacts
         run: find sources/ -type f \( -name "*.tar.gz" -o -name "*.tar.xz" -o -name "*.tgz" -o -name "*.tar.bz2" -o -name "*.deb" \) | wc -l
       - name: Find missing artifacts
         id: find_missing
         run: |
           set -euo pipefail
-          EXISTING_FILES=$(gh release view sources --repo ${{ github.repository_owner }}/distribution-sources --json assets --jq '.assets[].name' || true)
+          EXISTING_FILES=$(gh release view sources --repo "${{ github.repository_owner }}/distribution-sources" --json assets --jq '.assets[].name' || true)
           mapfile -t LOCAL_FILES < <(find sources/ -type f \( -name '*.tar.gz' -o -name '*.tar.xz' -o -name '*.tgz' -o -name '*.tar.bz2' -o -name '*.deb' -o -name '*.tar.zst' \))
           
           MISSING_FILES=()
@@ -65,12 +58,12 @@ jobs:
             fi
           done
           
-          if [ ${#MISSING_FILES[@]} -eq 0 ]; then
+          if [ "${#MISSING_FILES[@]}" -eq 0 ]; then
             echo "No missing files to upload."
-            echo "HAS_MISSING=false" >> $GITHUB_ENV
+            echo "HAS_MISSING=false" >> "$GITHUB_ENV"
           else
-            echo "ARTIFACTS=$(IFS=,; echo "${MISSING_FILES[*]}")" >> $GITHUB_ENV
-            echo "HAS_MISSING=true" >> $GITHUB_ENV
+            printf 'ARTIFACTS=%s\n' "$(IFS=,; echo "${MISSING_FILES[*]}")" >> "$GITHUB_ENV"
+            echo "HAS_MISSING=true" >> "$GITHUB_ENV"
           fi
       - name: push sources
         if: env.HAS_MISSING == 'true'

--- a/distributions/ROCKNIX/options
+++ b/distributions/ROCKNIX/options
@@ -183,7 +183,7 @@
   BTOP_TOOL="yes"
 
 # Distribution Specific source location
-  DISTRO_MIRROR="https://github.com/ROCKNIX/distribution-sources/releases/download/sources"
+  DISTRO_MIRROR="${ROCKNIX_SOURCE_MIRROR:-https://github.com/${GITHUB_REPOSITORY_OWNER:-ROCKNIX}/distribution-sources/releases/download/sources}"
   DISTRO_SRC="https://sources.libreelec.tv/$DISTRO_VERSION"
 
 # Default size of system partition, in MB, eg. 512

--- a/scripts/get
+++ b/scripts/get
@@ -42,6 +42,10 @@ if [ -n "${PKG_URL}" -a -n "${PKG_SOURCE_NAME}" ]; then
       ;;
   esac
 
+  if [ "${get_handler}" = "git" ] && [ "${SKIP_GIT}" = "true" ]; then
+    exit 0
+  fi
+
   if ! listcontains "${GET_HANDLER_SUPPORT}" "${get_handler}"; then
     die "ERROR: get handler \"${get_handler}\" is not supported, unable to get package ${1} - aborting!"
   else

--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -35,8 +35,12 @@ then
   PKG_URLS="${PKG_URL} ${PACKAGE_MIRROR}"
 fi
 
-NBWGET=10
-while [ ${NBWGET} -gt 0 ]; do
+NBWGET="${GET_MAX_ATTEMPTS:-10}"
+if ! [[ "${NBWGET}" =~ ^[1-9][0-9]*$ ]]; then
+  die "GET_MAX_ATTEMPTS must be a positive integer"
+fi
+
+while [ "${NBWGET}" -gt 0 ]; do
   for url in ${PKG_URLS}; do
     rm -f "${PACKAGE}"
     if ${WGET_CMD} "${url}"; then
@@ -50,7 +54,8 @@ while [ ${NBWGET} -gt 0 ]; do
   NBWGET=$((NBWGET - 1))
 done
 
-if [ ${NBWGET} -eq 0 ]; then
+if [ "${NBWGET}" -eq 0 ]; then
+  rm -f "${PACKAGE}"
   die "\nCannot get ${1} sources : ${PKG_URL}\nTry later!"
 else
   build_msg "CLR_INFO" "INFO" "Calculated checksum: ${CALC_SHA256}"

--- a/tools/download-tool
+++ b/tools/download-tool
@@ -27,25 +27,29 @@ esac
 declare -A fetched_packages
 declare -a failed_packages
 
-for package in $(find projects/ROCKNIX/packages/ -name package.mk); do
-  if [[ "$package" == *addons* && -z "$ALL_PACKAGES" ]]; then
-    continue
+if [[ -n "$ALL_PACKAGES" ]]; then
+  mapfile -t packages < <(find projects/ROCKNIX/packages/ packages/ -name package.mk)
+  for package in "${packages[@]}"; do
+    name=$(basename "$(dirname "$package")")
+    if [[ -n "${fetched_packages[$name]}" ]]; then
+      continue
+    fi
+    fetched_packages["$name"]=1
+  done
+else
+  plan_file=$(mktemp)
+  trap 'rm -f "$plan_file"' EXIT
+  if ! ./tools/viewplan image > "$plan_file"; then
+    echo "Failed to generate the image build plan." >&2
+    exit 1
   fi
-  name=$(basename "$(dirname "$package")")
-  if ! ./scripts/get "$name"; then
-    failed_packages+=("$name")
-  fi
-  fetched_packages["$name"]=1
-done
 
-for package in $(find packages/ -name package.mk); do
-  if [[ "$package" == *addons* && -z "$ALL_PACKAGES" ]]; then
-    continue
-  fi
-  name=$(basename "$(dirname "$package")")
-  if [[ -n "${fetched_packages[$name]}" ]]; then
-    continue
-  fi
+  while read -r name; do
+    fetched_packages["$name"]=1
+  done < <(awk 'NF >= 2 { name=$2; sub(/:.*/, "", name); print name }' "$plan_file" | sort -u)
+fi
+
+for name in "${!fetched_packages[@]}"; do
   if ! ./scripts/get "$name"; then
     failed_packages+=("$name")
   fi

--- a/tools/download-tool
+++ b/tools/download-tool
@@ -25,13 +25,16 @@ case $1 in
 esac
 
 declare -A fetched_packages
+declare -a failed_packages
 
 for package in $(find projects/ROCKNIX/packages/ -name package.mk); do
   if [[ "$package" == *addons* && -z "$ALL_PACKAGES" ]]; then
     continue
   fi
   name=$(basename "$(dirname "$package")")
-  ./scripts/get "$name"
+  if ! ./scripts/get "$name"; then
+    failed_packages+=("$name")
+  fi
   fetched_packages["$name"]=1
 done
 
@@ -43,5 +46,12 @@ for package in $(find packages/ -name package.mk); do
   if [[ -n "${fetched_packages[$name]}" ]]; then
     continue
   fi
-  ./scripts/get "$name"
+  if ! ./scripts/get "$name"; then
+    failed_packages+=("$name")
+  fi
 done
+
+if [ "${#failed_packages[@]}" -gt 0 ]; then
+  printf 'Failed to download %d package(s): %s\n' "${#failed_packages[@]}" "${failed_packages[*]}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Description

Make source mirror selection consistent with the repository that runs the mirror update workflow, and prevent failed upstream responses from contaminating the mirror.

- use `<repository owner>/distribution-sources` automatically in GitHub Actions
- preserve the existing ROCKNIX mirror as the local-build default
- allow an explicit `ROCKNIX_SOURCE_MIRROR` override
- continue through individual device download failures so successfully fetched archives are still uploaded
- make archive retry rounds configurable while retaining the existing default for normal builds
- report aggregate failures from `tools/download-tool` instead of silently succeeding
- remove the last invalid archive after retries are exhausted
- upload only files with a checksum stamp whose SHA-256 matches the actual archive
- include every validated source format instead of a partial extension allowlist
- audit only source archives required by the selected device image and honor packages that set `SKIP_GIT`

This provides a reusable fallback for transient or retired upstream download URLs instead of requiring every source outage to block all builds. Package checksums remain enforced both while downloading and again before mirror upload.

## Testing

- `actionlint .github/workflows/update-mirror-sources.yml`
- `bash -n scripts/get_archive tools/download-tool`
- `git diff --check`
- verified owner-derived, explicit override, and local default mirror resolution
- completed an RK3326 mirror update workflow successfully
- uploaded 746 checksum-verified source assets (10.27 GB) to a repository-owned mirror
- confirmed the workflow reported 14 unavailable packages, continued, and uploaded the remaining valid sources
- confirmed no missing-archive or invalid-checksum file reached the upload set
- aggregate RK3326 dependency audit [32933749369](https://github.com/pigpigyyy/distribution_rocknix/actions/runs/32933749369) passed after all retired sources were repaired
- complete RK3326 image build [32955106824](https://github.com/pigpigyyy/distribution_rocknix/actions/runs/32955106824) passed with the repository-owned mirror, including modules and all three final artifacts

## Build target

`build:RK3326`